### PR TITLE
Bugfix: Table sort and search functionality.

### DIFF
--- a/copy_this/modules/mudeprepayment/views/admin/tpl/mude_prepayment_order_list.tpl
+++ b/copy_this/modules/mudeprepayment/views/admin/tpl/mude_prepayment_order_list.tpl
@@ -38,56 +38,52 @@ window.onload = function ()
 </script>
 
 <div id="liste">
-
 <form name="search" id="search" action="[{ $oViewConf->getSelfLink() }]" method="post">
-    [{ $oViewConf->getHiddenSid() }]
-    <input type="hidden" name="cl" value="mude_prepayment_order_list">
-    <input type="hidden" name="lstrt" value="[{ $lstrt }]">
-    <input type="hidden" name="sort" value="[{ $sort }]">
-    <input type="hidden" name="actedit" value="[{ $actedit }]">
-    <input type="hidden" name="oxid" value="[{ $oxid }]">
-    <input type="hidden" name="fnc" value="">
-
+[{include file="_formparams.tpl" cl="mude_prepayment_order_list" lstrt=$lstrt actedit=$actedit oxid=$oxid fnc="" language=$actlang editlanguage=$actlang}]
 <table cellspacing="0" cellpadding="0" border="0" width="100%">
-    <colgroup><col width="25%"><col width="25%"><col width="10%"><col width="28%"><col width="10%"><col width="1%"><col width="1%"></colgroup>
+  [{block name="mude_prepayment_order_list_colgroup"}]
+  <colgroup><col width="25%"><col width="25%"><col width="10%"><col width="28%"><col width="10%"><col width="1%"><col width="1%"></colgroup>
+  [{/block}]
     <tr class="listitem">
+      [{block name="mude_prepayment_order_list_filter"}]
     <td valign="top" class="listfilter first" height="20">
-        <div class="r1"><div class="b1">
+      <div class="r1"><div class="b1">
         <select name="folder" class="folderselect" onChange="document.search.submit();">
             <option value="-1" style="color: #000000;">[{ oxmultilang ident="ORDER_LIST_FOLDER_ALL" }]</option>
             [{foreach from=$afolder key=field item=color}]
             <option value="[{ $field }]" [{ if $folder == $field }]SELECTED[{/if}] style="color: [{ $color }];">[{ oxmultilang ident=$field noerror=true }]</option>
             [{/foreach}]
         </select>
-        <input class="listedit" type="text" size="15" maxlength="128" name="where[oxorder.oxorderdate]" value="[{ $where->oxorder__oxorderdate|oxformdate }]" [{include file="help.tpl" helpid=order_date}]>
+        <input class="listedit" type="text" size="15" maxlength="128" name="where[oxorder][oxorderdate]" value="[{ $where->oxorder__oxorderdate|oxformdate }]" [{include file="help.tpl" helpid=order_date}]>
         </div></div>
     </td>
         <td valign="top" class="listfilter" height="20">
         <div class="r1"><div class="b1">
-        <input class="listedit" type="text" size="7" maxlength="128" name="where[oxorder.oxordernr]" value="[{ $where->oxorder__oxordernr }]">
+        <input class="listedit" type="text" size="7" maxlength="128" name="where[oxorder][oxordernr]" value="[{ $where->oxorder__oxordernr }]">
         </div></div>
     </td>
     <td valign="top" class="listfilter" height="20" colspan="1" nowrap>
         <div class="r1"><div class="b1">
         <div class="find"><input class="listedit" type="submit" name="submitit" value="[{ oxmultilang ident="GENERAL_SEARCH" }]"></div>
-        <input class="listedit" type="text" size="50" maxlength="128" name="where[oxorder.oxbilllname]" value="[{ $where->oxorder__oxbilllname }]">
+        <input class="listedit" type="text" size="50" maxlength="128" name="where[oxorder][oxbilllname]" value="[{ $where->oxorder__oxbilllname }]">
         </div></div>
     </td>
-    
+
     <td valign="top" class="listfilter" height="20" colspan="3" nowrap>
         <div class="r1"><div class="b1">
         <div class="find"></div>
         </div></div>
     </td>
-    
+    [{/block}]
 </tr>
-<tr>
-    <td class="listheader first" height="15">&nbsp;<a href="Javascript:document.search.sort.value='oxorder.oxorderdate';document.search.submit();" class="listheader">[{ oxmultilang ident="ORDER_LIST_ORDERTIME" }]</a></td>
-    <td class="listheader" height="15"><a href="Javascript:document.search.sort.value='oxorder.oxordernr';document.search.submit();" class="listheader">[{ oxmultilang ident="GENERAL_ORDERNUM" }]</a></td>
-    <td class="listheader" height="15"  colspan="1"><a href="Javascript:document.search.sort.value='oxorder.oxbilllname';document.search.submit();" class="listheader">[{ oxmultilang ident="ORDER_LIST_CUSTOMER" }]</a></td>
-    
-     <td class="listheader" height="15"  colspan="3"><a href="Javascript:document.search.sort.value='oxorder.oxbilllname';document.search.submit();" class="listheader">[{ oxmultilang ident="MUDE_PREPAYMENT_HEADLINE" }]</a></td>
-    
+    <tr>
+      [{block name="mude_prepayment_order_list_sorting"}]
+      <td class="listheader first" height="15">&nbsp;<a href="javascript:top.oxid.admin.setSorting( document.search, 'oxorder', 'oxorderdate', 'asc');document.search.submit();" class="listheader">[{ oxmultilang ident="ORDER_LIST_ORDERTIME" }]</a></td>
+    <td class="listheader" height="15"><a href="javascript:top.oxid.admin.setSorting( document.search, 'oxorder', 'oxordernr', 'asc');document.search.submit();" class="listheader">[{ oxmultilang ident="GENERAL_ORDERNUM" }]</a></td>
+    <td class="listheader" height="15"  colspan="1"><a href="javascript:top.oxid.admin.setSorting( document.search, 'oxorder', 'oxbilllname', 'asc');document.search.submit();" class="listheader">[{ oxmultilang ident="ORDER_LIST_CUSTOMER" }]</a></td>
+
+     <td class="listheader" height="15"  colspan="3"><a href="javascript:top.oxid.admin.setSorting( document.search, 'oxorder', 'mudeprepaymentreminded', 'asc');document.search.submit();" class="listheader">[{ oxmultilang ident="MUDE_PREPAYMENT_HEADLINE" }]</a></td>
+     [{/block}]
 </tr>
 
 [{assign var="blWhite" value=""}]
@@ -95,7 +91,7 @@ window.onload = function ()
 [{foreach from=$mylist item=listitem}]
     [{assign var="_cnt" value=$_cnt+1}]
     <tr id="row.[{$_cnt}]">
-
+      [{block name="mude_prepayment_order_list_item"}]
     [{ if $listitem->oxorder__oxstorno->value == 1 }]
         [{assign var="listclass" value=listitem3 }]
     [{else}]
@@ -113,13 +109,13 @@ window.onload = function ()
     <td valign="top" class="[{ $listclass}]" height="15"><div class="listitemfloating"><a href="Javascript:top.oxid.admin.editThis('[{ $listitem->oxorder__oxid->value}]');" class="[{ $listclass}]">[{ $listitem->oxorder__oxbilllname->value }] [{ $listitem->oxorder__oxbillfname->value }]</a></div></td>
     <td class="[{ $listclass}]">
         [{ $listitem->oxorder__mudeprepaymentreminded->value }]
-        </td>
-
+    </td>
     <td class="[{ $listclass}]" colspan="2">
         [{if !$readonly}]
             <a href="Javascript:Mude_RemindCustomer('[{ $listitem->oxorder__oxid->value }]');" id="pau.[{$_cnt}]" class="pause"></a>
-        [{/if}]</td>
+        [{/if}]
     </td>
+    [{/block}]
 </tr>
 [{if $blWhite == "2"}]
 [{assign var="blWhite" value=""}]
@@ -145,4 +141,3 @@ if (parent.parent)
 </script>
 </body>
 </html>
-


### PR DESCRIPTION
The Table sort and search functionality wasn't working correctly in CE 4.10.x.

Also added [{block}] elements (see order_list.tpl in Oxid-Shop 4.10.x
CE) and removed an unnecessary '</td>' tag.

The template is now including a file '_formparams.tpl'. It contains the
hidden parameters used in the admin-views. This file is part of the
Oxid-Shop Software. It should be located in application/views/admin/tpl/.

Could be that this change breaks backward compatibility.

Tested only
against Version 4.10.x CE.